### PR TITLE
Use helper function call_here() to avoid repetition

### DIFF
--- a/R/R_zmq_context.r
+++ b/R/R_zmq_context.r
@@ -44,7 +44,7 @@ NULL
 #' @rdname a0_d_context
 #' @export
 zmq.ctx.new <- function(){
-  ret <- .Call("R_zmq_ctx_new", PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_ctx_new")
   ### Users are responsible to take care free and gc.
   # reg.finalizer(ret, zmq.ctx.destroy, TRUE)
   ret
@@ -55,7 +55,7 @@ zmq.ctx.new <- function(){
 #' @rdname a0_d_context
 #' @export
 zmq.ctx.destroy <- function(ctx){
-  .Call("R_zmq_ctx_destroy", ctx, PACKAGE = "pbdZMQ")
+  call_here("R_zmq_ctx_destroy", ctx)
   invisible()
 }
 

--- a/R/R_zmq_message.r
+++ b/R/R_zmq_message.r
@@ -71,13 +71,13 @@ NULL
 
 
 zmq.msg.init <- function(){
-  .Call("R_zmq_msg_init", PACKAGE = "pbdZMQ")
+  call_here("R_zmq_msg_init")
 }
 
 
 
 zmq.msg.close <- function(msg.t){
-  .Call("R_zmq_msg_close", msg.t, PACKAGE = "pbdZMQ")
+  call_here("R_zmq_msg_close", msg.t)
 }
 
 
@@ -89,7 +89,7 @@ zmq.msg.send <- function(rmsg, socket, flags = .pbd_env$ZMQ.SR$BLOCK,
   if(serialize){
     rmsg <- serialize(rmsg, NULL)
   }
-  ret <- .Call("R_zmq_msg_send", rmsg, socket, as.integer(flags), PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_msg_send", rmsg, socket, as.integer(flags))
   invisible(ret)
 }
 
@@ -99,7 +99,7 @@ zmq.msg.send <- function(rmsg, socket, flags = .pbd_env$ZMQ.SR$BLOCK,
 #' @export
 zmq.msg.recv <- function(socket, flags = .pbd_env$ZMQ.SR$BLOCK,
                          unserialize = TRUE){
-  rmsg <- .Call("R_zmq_msg_recv", socket, as.integer(flags), PACKAGE = "pbdZMQ")
+  rmsg <- call_here("R_zmq_msg_recv", socket, as.integer(flags))
   if(unserialize && is.raw(rmsg)){
     rmsg <- unserialize(rmsg)
   }

--- a/R/R_zmq_poll.r
+++ b/R/R_zmq_poll.r
@@ -126,9 +126,8 @@ zmq.poll <- function(socket, type, timeout = -1L, MC = .pbd_env$ZMQ.MC){
 
   zmq.poll.free()
 
-  ret <- .Call("R_zmq_poll", socket, type, as.integer(timeout),
-               as.logical(MC$check.eintr),
-               PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_poll", socket, type, as.integer(timeout),
+               as.logical(MC$check.eintr))
   return(invisible(ret))
 }
 
@@ -136,14 +135,14 @@ zmq.poll <- function(socket, type, timeout = -1L, MC = .pbd_env$ZMQ.MC){
 #' @rdname b3_poll
 #' @export
 zmq.poll.free <- function(){
-  ret <- .Call("R_zmq_poll_free", PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_poll_free")
   invisible(ret)
 }
 
 #' @rdname b3_poll
 #' @export
 zmq.poll.length <- function(){
-  ret <- .Call("R_zmq_poll_length", PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_poll_length")
   invisible(ret)
 }
 
@@ -153,7 +152,6 @@ zmq.poll.get.revents <- function(index = 1L){
   if(index < 1){
     stop("index is a positive interger.")
   }
-  ret <- .Call("R_zmq_poll_get_revents", as.integer(index - 1)[1],
-               PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_poll_get_revents", as.integer(index - 1)[1])
   invisible(ret)
 }

--- a/R/R_zmq_sendrecv.r
+++ b/R/R_zmq_sendrecv.r
@@ -103,16 +103,16 @@ zmq.send <- function(socket, buf, flags = .pbd_env$ZMQ.SR$BLOCK){
 
 
 zmq.send.char <- function(socket, buf, len, flags = .pbd_env$ZMQ.SR$BLOCK){
-  ret <- .Call("R_zmq_send_char", socket, buf, as.integer(len),
-               as.integer(flags), PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_send_char", socket, buf, as.integer(len),
+               as.integer(flags))
   invisible(ret)
 }
 
 
 
 zmq.send.raw <- function(socket, buf, len, flags = .pbd_env$ZMQ.SR$BLOCK){
-  ret <- .Call("R_zmq_send_raw", socket, buf, as.integer(len),
-               as.integer(flags), PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_send_raw", socket, buf, as.integer(len),
+               as.integer(flags))
   invisible(ret)
 }
 
@@ -135,16 +135,14 @@ zmq.recv <- function(socket, len = 1024L, flags = .pbd_env$ZMQ.SR$BLOCK,
 
 
 zmq.recv.char <- function(socket, len, flags = .pbd_env$ZMQ.SR$BLOCK){
-  ret <- .Call("R_zmq_recv_char", socket, as.integer(len), as.integer(flags),
-               PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_recv_char", socket, as.integer(len), as.integer(flags))
   invisible(ret)
 }
 
 
 
 zmq.recv.raw <- function(socket, len, flags = .pbd_env$ZMQ.SR$BLOCK){
-  ret <- .Call("R_zmq_recv_raw", socket, as.integer(len), as.integer(flags),
-               PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_recv_raw", socket, as.integer(len), as.integer(flags))
   invisible(ret)
 }
 

--- a/R/R_zmq_socket.r
+++ b/R/R_zmq_socket.r
@@ -114,7 +114,7 @@ NULL
 #' @rdname a1_socket
 #' @export
 zmq.socket <- function(ctx, type = .pbd_env$ZMQ.ST$REP){
-  ret <- .Call("R_zmq_socket", ctx, type, PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_socket", ctx, type)
   attr(ret, "type") = type
   ### Users are responsible to take care free and gc.
   # reg.finalizer(ret, zmq.close, TRUE)
@@ -126,7 +126,7 @@ zmq.socket <- function(ctx, type = .pbd_env$ZMQ.ST$REP){
 #' @rdname a1_socket
 #' @export
 zmq.close <- function(socket){
-  ret <- .Call("R_zmq_close", socket, PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_close", socket)
   invisible(ret)
 }
 
@@ -135,7 +135,7 @@ zmq.close <- function(socket){
 #' @rdname a1_socket
 #' @export
 zmq.bind <- function(socket, endpoint, MC = .pbd_env$ZMQ.MC){
-  ret <- .Call("R_zmq_bind", socket, endpoint, PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_bind", socket, endpoint)
 
   if(ret == -1){
     if(MC$stop.at.error){
@@ -156,7 +156,7 @@ zmq.bind <- function(socket, endpoint, MC = .pbd_env$ZMQ.MC){
 #' @rdname a1_socket
 #' @export
 zmq.connect <- function(socket, endpoint, MC = .pbd_env$ZMQ.MC){
-  ret <- .Call("R_zmq_connect", socket, endpoint, PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_connect", socket, endpoint)
 
   if(ret == -1){
     if(MC$stop.at.error){
@@ -177,7 +177,7 @@ zmq.connect <- function(socket, endpoint, MC = .pbd_env$ZMQ.MC){
 #' @rdname a1_socket
 #' @export
 zmq.disconnect <- function(socket, endpoint, MC = .pbd_env$ZMQ.MC){
-  ret <- .Call("R_zmq_disconnect", socket, endpoint, PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_disconnect", socket, endpoint)
 
   if(ret == -1){
     if(MC$stop.at.error){
@@ -206,8 +206,8 @@ zmq.setsockopt <- function(socket, option.name, option.value, MC = .pbd_env$ZMQ.
     stop("Type of option.value is not implemented")
   }
 
-  ret <- .Call("R_zmq_setsockopt", socket, option.name, option.value,
-               option.type, PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_setsockopt", socket, option.name, option.value,
+               option.type)
 
   if(ret == -1){
     if(MC$stop.at.error){
@@ -234,8 +234,8 @@ zmq.getsockopt <- function(socket, option.name, option.value, MC = .pbd_env$ZMQ.
     stop("Type of option.value is not implemented")
   }
 
-  ret <- .Call("R_zmq_getsockopt", socket, option.name, option.value,
-               option.type, PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_getsockopt", socket, option.name, option.value,
+               option.type)
 
   if(ret == -1){
     if(MC$stop.at.error){

--- a/R/R_zmq_transfer.r
+++ b/R/R_zmq_transfer.r
@@ -120,8 +120,8 @@ zmq.sendfile <- function(port, filename, verbose=FALSE,
   if (type == .pbd_env$ZMQ.ST$REQ)
     receive.socket(socket)
     
-    ret <- .Call("R_zmq_send_file", socket, filename, as.integer(verbose),
-      filesize, as.integer(flags), as.integer(forcebin), type, PACKAGE="pbdZMQ")
+    ret <- call_here("R_zmq_send_file", socket, filename, as.integer(verbose),
+      filesize, as.integer(flags), as.integer(forcebin), type)
   
   if (socket.close || ctx.destroy)
     zmq.close(socket)
@@ -176,8 +176,8 @@ zmq.recvfile <- function(port, endpoint, filename, verbose=FALSE,
   if (type == .pbd_env$ZMQ.ST$REP)
     send.socket(socket, NULL)
   
-  ret <- .Call("R_zmq_recv_file", socket, filename, as.integer(verbose),
-    filesize, as.integer(flags), as.integer(forcebin), type, PACKAGE="pbdZMQ")
+  ret <- call_here("R_zmq_recv_file", socket, filename, as.integer(verbose),
+    filesize, as.integer(flags), as.integer(forcebin), type)
 
   if (socket.close || ctx.destroy)
     zmq.close(socket)

--- a/R/R_zmq_utility.r
+++ b/R/R_zmq_utility.r
@@ -40,18 +40,16 @@
 NULL
 
 
-
 #' @rdname xx_utility
 #' @export
 zmq.strerror <- function(errno){
-  .Call("R_zmq_strerror", as.integer(errno[1]), PACKAGE = "pbdZMQ")
+  call_here("R_zmq_strerror", as.integer(errno[1]))
 }
 
 
 #' @rdname xx_utility
 #' @export
 zmq.version <- function(){
-  ret <- .Call("R_zmq_version", PACKAGE = "pbdZMQ")
+  ret <- call_here("R_zmq_version")
   package_version(ret)
 }
-

--- a/R/call_zmq.R
+++ b/R/call_zmq.R
@@ -1,0 +1,9 @@
+#' Call Compiled C Code From This Package
+#' 
+#' @param .NAME passed to \code{\link{.Call}}
+#' @param \dots passed to \code{\link{.Call}}
+#' 
+call_here <- function(.NAME, ...) 
+{
+  .Call(.NAME, ..., PACKAGE = "pbdZMQ")
+} 

--- a/R/shellexec_wcc.r
+++ b/R/shellexec_wcc.r
@@ -54,7 +54,7 @@
 #' @rdname u0_shellexec.wcc
 shellexec.wcc <- function(file, SW.cmd = 7L){
   if(length(file) == 1 && is.character(file)){
-    .Call("shellexec_wcc", file, as.integer(SW.cmd), PACKAGE="pbdZMQ")
+    call_here("shellexec_wcc", file, as.integer(SW.cmd))
   } else{
     stop("file should be a character vector of length 1.")
   }


### PR DESCRIPTION
This shortens the code, improves its readability and lowers the risk of a typo in the package name.